### PR TITLE
add buildkit-setup composite action

### DIFF
--- a/.github/actions/buildkit-setup/README.md
+++ b/.github/actions/buildkit-setup/README.md
@@ -1,0 +1,42 @@
+# buildkit-setup
+
+Composite action that wires up `docker/setup-buildx-action` against the shared
+rootless buildkitd in the `tooling-prod` EKS cluster. Use on any ARC runner
+before `docker/build-push-action`.
+
+## Usage
+
+```yaml
+jobs:
+  build:
+    runs-on: arc-runner-4
+    steps:
+      - uses: actions/checkout@v4
+      - uses: lightsparkdev/.github/actions/buildkit-setup@v1
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ...
+```
+
+That's it. No `setup-buildx-action` call of your own, no per-workflow TLS
+plumbing. The runner pod has the mTLS client cert mounted at
+`/etc/buildkit-client/{ca,tls.crt,tls.key}` (handled by the gha-runner-scale-set
+chart in `lightsparkdev/tooling-infra`).
+
+## Inputs
+
+| Name       | Default                                                            | Notes                                                                                                              |
+|------------|--------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|
+| `endpoint` | `tcp://buildkitd.buildkit.svc.cluster.local:1234`                  | Override for testing against a specific replica via per-pod DNS (`buildkitd-N.buildkitd.buildkit.svc.cluster.local`). |
+
+## Where this works
+
+- `runs-on: arc-runner-{1,2,4,8}` — the in-cluster ARC scale sets.
+- Not GH-hosted runners (the buildkit service is cluster-internal; the certs aren't there).
+
+## When NOT to use this
+
+- Workflows that need `services:` blocks (postgres, redis, etc.) — those need a real docker daemon, not just buildx.
+- `kind`/`tilt`-based hermetic tests — same reason. These should stay on GH-hosted.

--- a/.github/actions/buildkit-setup/action.yaml
+++ b/.github/actions/buildkit-setup/action.yaml
@@ -1,0 +1,26 @@
+name: "buildkit-setup"
+description: >
+  Point docker/setup-buildx-action at the shared buildkitd service in the
+  tooling-prod EKS cluster. Use this on any ARC runner before
+  `docker/build-push-action`.
+
+  The runner pod has the mTLS client cert pre-mounted at
+  /etc/buildkit-client (see charts/arc-runner/values.yaml in
+  lightsparkdev/tooling-infra). No per-workflow auth wiring needed.
+
+inputs:
+  endpoint:
+    description: "buildkitd TCP endpoint. Override for testing against a specific replica via per-pod DNS (e.g. tcp://buildkitd-2.buildkitd.buildkit.svc.cluster.local:1234)."
+    required: false
+    default: "tcp://buildkitd.buildkit.svc.cluster.local:1234"
+
+runs:
+  using: composite
+  steps:
+    - uses: docker/setup-buildx-action@v3
+      with:
+        driver: remote
+        endpoint: ${{ inputs.endpoint }}
+        cacert: /etc/buildkit-client/ca.crt
+        cert: /etc/buildkit-client/tls.crt
+        key: /etc/buildkit-client/tls.key


### PR DESCRIPTION
## Summary
Adds `lightsparkdev/.github/actions/buildkit-setup` — a composite action that wires `docker/setup-buildx-action` against the shared rootless buildkitd in the `tooling-prod` EKS cluster.

Workflow author shape goes from this:

```yaml
- uses: docker/setup-buildx-action@v3
- uses: docker/build-push-action@v6
```

to this, with no other diff:

```yaml
- uses: lightsparkdev/.github/actions/buildkit-setup@v1
- uses: docker/build-push-action@v6
```

The composite action handles `driver: remote`, the buildkitd Service endpoint, and the mTLS material (`/etc/buildkit-client/{ca.crt,tls.crt,tls.key}`, mounted into every ARC runner pod by `charts/arc-runner/values.yaml` in tooling-infra). Authors don't see any of the auth or transport plumbing.

## Depends on
- lightsparkdev/tooling-infra#30 — buildkit chart + arc-runner cert mount
- lightsparkdev/ops#2727 — cert-manager + ca/internal ClusterIssuers

Both should land before users start using this action.

## Tagging
After merge, tag as `v1` (or use a moving `v1` ref via the standard GH actions release flow) so workflows can pin `@v1`.

## Test plan
- [ ] Smoke-test workflow in `lightsparkdev/tooling-infra/.github/workflows/` builds + pushes a hello-world image via this action against an `arc-runner-N` runner.
- [ ] One real consumer migrates (e.g. `lightsparkdev/golinks/.github/workflows/ci.yml` — small, standalone). Verify `docker/build-push-action` succeeds and the layer cache survives a second build.